### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT"
 name = "tagsearch"
 readme = "README.md"
-repository = "https://www.github.com/ChrisDavison/tagsearch"
+repository = "https://github.com/ChrisDavison/tagsearch"
 version = "0.38.0"
 
 [[bin]]


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96